### PR TITLE
Analyze sr_api_field schema for domain handling

### DIFF
--- a/jaksho/jaksho-domain/src/main/java/top/huzz/jaksho/domain/entity/ApiField.java
+++ b/jaksho/jaksho-domain/src/main/java/top/huzz/jaksho/domain/entity/ApiField.java
@@ -59,6 +59,12 @@ public class ApiField extends BasicProperties implements Serializable {
     private Integer bizFieldId;
 
     /**
+     * 业务字段领域ID，引用sr_biz_field_domain.id。与bizFieldId互斥，优先使用此字段
+     */
+    @TableField("biz_field_domain_id")
+    private Integer bizFieldDomainId;
+
+    /**
      * 字段名称
      */
     @TableField("field_name")
@@ -113,6 +119,8 @@ public class ApiField extends BasicProperties implements Serializable {
     public static final String FIELD_TYPE = "field_type";
 
     public static final String BIZ_FIELD_ID = "biz_field_id";
+
+    public static final String BIZ_FIELD_DOMAIN_ID = "biz_field_domain_id";
 
     public static final String FIELD_NAME = "field_name";
 


### PR DESCRIPTION
Add `bizFieldDomainId` to `ApiField` to enable referencing domain-specific fields in API definitions.

Previously, `sr_api_field` could only reference base fields (`sr_biz_field`). This change introduces `biz_field_domain_id` to allow API fields to link to `sr_biz_field_domain` entries, providing a way to use fields with specific domain contexts. This design maintains backward compatibility with existing base field references, with `biz_field_domain_id` taking precedence if present.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee4e67e7-f4ed-4c9a-b16b-9d63d91ba88c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee4e67e7-f4ed-4c9a-b16b-9d63d91ba88c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

